### PR TITLE
fix(notifications): Fix bug where delete notification may result in a…

### DIFF
--- a/app/pods/application/route.coffee
+++ b/app/pods/application/route.coffee
@@ -91,8 +91,8 @@ ApplicationRoute = Ember.Route.extend ApplicationRouteMixin,
           # cancel does two things:  reload and rollback
           resourceRecord.cancel()
         when 'delete'
-          # mark as deleted
-          resourceRecord.deleteRecord()
+          # remove record from local store
+          resourceRecord.unloadRecord()
 
   loadingObserver: Ember.observer 'isLoading', ->
     isLoading = @get 'isLoading'

--- a/tests/acceptance/notification/delete-test.coffee
+++ b/tests/acceptance/notification/delete-test.coffee
@@ -1,0 +1,45 @@
+`import Ember from 'ember'`
+`import { module, test } from 'qunit'`
+`import startApp from 'gateway-ui/tests/helpers/start-app'`
+`import destroyApp from 'gateway-ui/tests/helpers/destroy-app'`
+`import { currentSession, authenticateSession, invalidateSession } from 'gateway-ui/tests/helpers/ember-simple-auth'`
+`import WebSocketMockServer from 'gateway-ui/tests/helpers/websocket-mock-server'`
+
+module 'Acceptance: Notification - Delete',
+  beforeEach: ->
+    @port = window?.location.port
+    ###
+    Don't return anything, because QUnit looks for a .then
+    that is present on Ember.Application, but is deprecated.
+    ###
+    return
+
+  afterEach: -> destroyApp @application
+
+test 'user cannot see deleted resource after delete notification', (assert) ->
+  done = assert.async()
+  new WebSocketMockServer "ws://localhost:#{@port}/admin/notifications", (wsServer) ->
+    Ember.run.later (->
+      apiCount = server.db.apis.length
+      assert.equal currentURL(), '/apis'
+      assert.equal apiCount > 0, true
+      assert.equal find('.ap-table-index tbody tr').length, apiCount
+      wsServer.open()
+      wsServer.message JSON.stringify
+        resource: 'api'
+        resource_id: server.db.apis[0].id
+        api_id: server.db.apis[0].id
+        action: 'delete'
+        user: 'developer@software.com'
+      assert.equal find('.ember-notify').length, 1
+      Ember.run.later (->
+        assert.equal find('.ap-table-index tbody tr').length, apiCount - 1
+        wsServer.destroy()
+        done()
+      ), 1000
+    ), 1000
+  @application = startApp notifications: true
+  server.createList 'api', 2
+  # wsServer is open, but no messages are sent
+  authenticateSession @application, email: 'foo@test.com'
+  visit '/apis'


### PR DESCRIPTION
… client-side error

When a user deletes a resource, it triggers a notification of a delete.  The user who intiated the

delete will receive this notificaiton.  The way a delete notification was handled was to call

`record.deleteRecord()`, which is incorrect in this scenario.  This is resolved by calling

`record.unloadRecord()` instead, which is expected to work both when a record was deleted by another

user or the current user.  Fixes [#137728433]