### PR TITLE
fix(notifications): Fixed bug where delete notification handled while…

### DIFF
--- a/app/pods/application/route.coffee
+++ b/app/pods/application/route.coffee
@@ -89,10 +89,19 @@ ApplicationRoute = Ember.Route.extend ApplicationRouteMixin,
       switch action
         when 'create', 'update'
           # cancel does two things:  reload and rollback
-          resourceRecord.cancel()
+          @runOnRecordWhenPossible resourceRecord, 'cancel'
         when 'delete'
           # remove record from local store
-          resourceRecord.unloadRecord()
+          @runOnRecordWhenPossible resourceRecord, 'unloadRecord'
+
+  # Runs the specified method on the record as soon as it is safe to do so,
+  # which is when immediately if the record is not currently saving, and on
+  # ready, if it is currently saving.
+  runOnRecordWhenPossible: (record, method) ->
+    if record.get 'isSaving'
+      record.one 'ready', record[method], record
+    else
+      record[method]()
 
   loadingObserver: Ember.observer 'isLoading', ->
     isLoading = @get 'isLoading'

--- a/tests/acceptance/notification/delete-test.coffee
+++ b/tests/acceptance/notification/delete-test.coffee
@@ -16,7 +16,7 @@ module 'Acceptance: Notification - Delete',
 
   afterEach: -> destroyApp @application
 
-test 'user cannot see deleted resource after delete notification', (assert) ->
+test 'user cannot see a deleted resource after delete notification', (assert) ->
   done = assert.async()
   new WebSocketMockServer "ws://localhost:#{@port}/admin/notifications", (wsServer) ->
     Ember.run.later (->
@@ -43,3 +43,40 @@ test 'user cannot see deleted resource after delete notification', (assert) ->
   # wsServer is open, but no messages are sent
   authenticateSession @application, email: 'foo@test.com'
   visit '/apis'
+
+test 'user cannot see a deleted resource after deleting and receiving a delete notification', (assert) ->
+  done = assert.async()
+  new WebSocketMockServer "ws://localhost:#{@port}/admin/notifications", (wsServer) ->
+    Ember.run.later (->
+      count = server.db.proxyEndpoints.length
+      assert.equal currentURL(), '/apis/1/proxy-endpoints'
+      assert.equal count > 0, true
+      assert.equal find('.ap-table-auto-index tbody tr').length, count
+      click '.ap-table-auto-index tbody tr:eq(0) td:eq(0) a'
+      andThen ->
+        wsServer.open()
+        assert.equal currentURL(), '/apis/1/proxy-endpoints/1/edit'
+        $('a[data-t="actions.delete"]').click()
+        wsServer.message JSON.stringify
+          resource: 'proxy-endpoint'
+          resource_id: server.db.proxyEndpoints[0].id
+          api_id: server.db.apis[0].id
+          action: 'delete'
+          user: 'developer@software.com'
+        andThen ->
+          assert.equal find('.ember-notify').length, 1
+        Ember.run.later (->
+          assert.equal currentURL(), '/apis/1/proxy-endpoints'
+          assert.equal find('.ap-table-auto-index tbody tr').length, count - 1
+          wsServer.destroy()
+          done()
+        ), 1000
+    ), 1000
+  @application = startApp notifications: true
+  server.createList('api', 1).forEach (api) ->
+    server.createList 'environment', 3, apiId: api.id
+    server.createList 'endpoint_group', 5, apiId: api.id
+    server.createList 'proxy_endpoint', 2, apiId: api.id
+  # wsServer is open, but no messages are sent
+  authenticateSession @application, email: 'foo@test.com'
+  visit '/apis/1/proxy-endpoints'


### PR DESCRIPTION
… delete request is in-flight ca

Attempting to unload a record that is in-flight causes an error, which happens when a delete

notification is received so quickly as to be handled before a delete request is complete.  This is

resolved in the application router by checking if the record `isSaving` and waiting for completion

if so.  Fixes [#137728433]