### PR TITLE
fix(service-worker): Add missing service worker dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "ember-load-initializers": "^0.5.1",
     "ember-notify": "aexmachina/ember-notify.git",
     "ember-resolver": "^2.0.3",
+    "ember-service-worker": "nanoscale-randy/ember-service-worker#feature-remove-root-prefix",
+    "ember-service-worker-asset-cache": "nanoscale-randy/ember-service-worker-asset-cache#feature-auto-files",
     "ember-simple-auth": "nanoscale-randy/ember-simple-auth#b7be974e95a52025038d01f6482234c53a35ad46",
     "ember-spin-spinner": "0.2.4",
     "ember-truncate-text": "0.0.1",


### PR DESCRIPTION
Service worker dependencies were unintentionally omitted from the last release