### PR TITLE
fix(cors): Fix scratch pad execute requests that were missing credent…

### DIFF
--- a/app/pods/remote-endpoint-environment-datum-scratch-pad/adapter.coffee
+++ b/app/pods/remote-endpoint-environment-datum-scratch-pad/adapter.coffee
@@ -19,6 +19,9 @@ RemoteEndpointEnvironmentDatumScratchPadAdapter = ApplicationAdapter.extend
         url: url
         type: 'GET'
         dataType: 'json'
+        crossDomain: true
+        xhrFields:
+          withCredentials: true
       .then (response) ->
         resolve response
       , (xhr, status, error) ->


### PR DESCRIPTION
…ials

Scratch pad execute requests were being made without the cross-domain or credentials flags enabled,
which would result in authentication failure.  Fixes [#138362619]