### PR TITLE
fix(i18n): Rely less on pre-rendered translations

### DIFF
--- a/app/pods/components/forms/json-node-form/component.coffee
+++ b/app/pods/components/forms/json-node-form/component.coffee
@@ -12,7 +12,7 @@ JsonNodeFormComponent = BaseFormComponent.extend
   defaultFields: Ember.computed 'model.type', 'model.mustHaveName', 'model.canHaveValue', 'model.isRoot', ->
     fields = [
       name: 'type'
-      type: 'select'
+      type: 'select-name-key'
       disabled: @get 'model.isRoot'
     ]
     if @get 'model.mustHaveName'

--- a/app/pods/components/forms/json-schema-node-form/component.coffee
+++ b/app/pods/components/forms/json-schema-node-form/component.coffee
@@ -13,7 +13,7 @@ JsonSchemaNodeFormComponent = BaseFormComponent.extend
   defaultFields: Ember.computed 'model.parentIsObject', 'model.isRoot', ->
     fields = [
       name: 'type'
-      type: 'select'
+      type: 'select-name-key'
     ,
       name: 'title'
       required: @get 'model.isRoot'

--- a/app/pods/components/forms/remote-endpoint-form/component.coffee
+++ b/app/pods/components/forms/remote-endpoint-form/component.coffee
@@ -21,7 +21,7 @@ RemoteEndpointFormComponent = BaseRemoteEndpointFormComponent.extend
   newFields: [
     name: 'type'
     required: true
-    type: 'select'
+    type: 'select-name-key'
   ]
 
   submit: ->

--- a/app/pods/components/forms/remote-endpoint-push-platform-form/component.coffee
+++ b/app/pods/components/forms/remote-endpoint-push-platform-form/component.coffee
@@ -19,7 +19,7 @@ RemoteEndpointPushPlatformFormComponent = BaseFormComponent.extend
     ,
       name: 'type'
       required: true
-      type: 'select'
+      type: 'select-name-key'
     ]
 
   platformFields:

--- a/app/pods/job-component/model.coffee
+++ b/app/pods/job-component/model.coffee
@@ -54,15 +54,18 @@ JobComponent = Model.extend
     set: (key, value) ->
       @set 'type', 'js' if value?
       @get 'js'
-  name: Ember.computed 'type', ->
+  nameKey: Ember.computed 'type', 'shared', ->
     type = @get 'type'
     type = 'shared' if @get 'shared'
-    t("types.proxy-endpoint-component.#{type}").capitalize()
+    "types.proxy-endpoint-component.#{type}"
+  name: Ember.computed 'nameKey', ->
+    t @get('nameKey')
 
 
 # Declare available types and their human-readable names
 types = 'single multi js'.split(' ').map (type) ->
   name: t "types.proxy-endpoint-component.#{type}"
+  nameKey: "types.proxy-endpoint-component.#{type}"
   slug: type
   value: type
 

--- a/app/pods/json-node/model.coffee
+++ b/app/pods/json-node/model.coffee
@@ -35,7 +35,7 @@ JsonNode = Model.extend
     JsonNode.types.findBy 'value', type
   displayName: Ember.computed 'canHaveValue', 'type', 'name', 'value', ->
     canHaveValue = @get 'canHaveValue'
-    type = @get 'nodeType.name'
+    type = t @get('nodeType.nameKey')
     name = @get 'name'
     value = @get 'value' if canHaveValue
     nameAndValue = "#{name}: #{value}" if name and value
@@ -43,6 +43,7 @@ JsonNode = Model.extend
 
 types = 'object array null boolean number string'.split(' ').map (typeName) ->
   name: t("types.json-type.#{typeName}").toLowerCase()
+  nameKey: "types.json-type.#{typeName}"
   slug: typeName
   value: typeName
 

--- a/app/pods/json-schema-node/model.coffee
+++ b/app/pods/json-schema-node/model.coffee
@@ -48,13 +48,14 @@ JsonSchemaNode = Model.extend
   canHaveChildren: Ember.computed 'type', ->
     (@get('type') is 'object') or (@get('type') is 'array')
   displayName: Ember.computed 'title', 'name', 'pattern', 'type', ->
-    @get('title') or @get('name') or @get('pattern') or @get('nodeType.name')
+    @get('title') or @get('name') or @get('pattern') or t @get('nodeType.nameKey')
   nodeType: Ember.computed 'type', ->
     type = @get 'type'
     JsonSchemaNode.types.findBy 'value', type
 
 types = 'object array null boolean integer number string'.split(' ').map (typeName) ->
   name: t("types.json-type.#{typeName}").toLowerCase()
+  nameKey: "types.json-type.#{typeName}"
   slug: typeName
   value: typeName
 

--- a/app/pods/proxy-endpoint-component/model.coffee
+++ b/app/pods/proxy-endpoint-component/model.coffee
@@ -54,15 +54,18 @@ ProxyEndpointComponent = Model.extend
     set: (key, value) ->
       @set 'type', 'js' if value?
       @get 'js'
-  name: Ember.computed 'type', ->
+  nameKey: Ember.computed 'type', 'shared', ->
     type = @get 'type'
     type = 'shared' if @get 'shared'
-    t("types.proxy-endpoint-component.#{type}").capitalize()
+    "types.proxy-endpoint-component.#{type}"
+  name: Ember.computed 'nameKey', ->
+    t @get('nameKey')
 
 
 # Declare available types and their human-readable names
 types = 'single multi js'.split(' ').map (type) ->
   name: t "types.proxy-endpoint-component.#{type}"
+  nameKey: "types.proxy-endpoint-component.#{type}"
   slug: type
   value: type
 

--- a/app/pods/proxy-endpoint-test/model.coffee
+++ b/app/pods/proxy-endpoint-test/model.coffee
@@ -37,6 +37,7 @@ ProxyEndpointTest = Model.extend
 # Declare available methods and their human-readable names
 methods = 'get post put delete'.split(' ').map (method) ->
   name: t "http-methods.#{method}"
+  nameKey: "http-methods.#{method}"
   slug: method
   value: method.toUpperCase()
 

--- a/app/pods/remote-endpoint-like/model.coffee
+++ b/app/pods/remote-endpoint-like/model.coffee
@@ -175,31 +175,37 @@ RemoteEndpointLike = Model.extend
 # Declare available types and their human-readable names
 types = 'http soap sqlserver postgres mysql mongodb ldap script hana store push redis oracle smtp db2 docker job key'.split(' ').map (type) ->
   name: t "types.remote-endpoint.#{type}"
+  nameKey: "types.remote-endpoint.#{type}"
   slug: type
   value: type
 
 statusTypes = 'success failed pending processing'.split(' ').map (type) ->
   name: t "types.remote-endpoint.status-types.#{type}"
+  nameKey: "types.remote-endpoint.status-types.#{type}"
   slug: type
   value: type.underscore()
 
 encryptModes = 'disable true false'.split(' ').map (mode) ->
   name: t "types.remote-endpoint.encrypt-modes.#{mode}"
+  nameKey: "types.remote-endpoint.encrypt-modes.#{mode}"
   slug: mode
   value: mode
 
 sslModes = 'disable allow prefer require'.split(' ').map (mode) ->
   name: t "types.remote-endpoint.ssl-modes.#{mode}"
+  nameKey: "types.remote-endpoint.ssl-modes.#{mode}"
   slug: mode
   value: mode
 
 authSchemes = 'basic wsse'.split(' ').map (scheme) ->
   name: t "types.remote-endpoint.auth-schemes.#{scheme}"
+  nameKey: "types.remote-endpoint.auth-schemes.#{scheme}"
   slug: scheme
   value: scheme
 
 protocols = 'tcpip ssl'.split(' ').map (protocol) ->
   name: t "types.remote-endpoint.protocols.#{protocol}"
+  nameKey: "types.remote-endpoint.protocols.#{protocol}"
   slug: protocol
   value: protocol.toUpperCase()
 

--- a/app/pods/remote-endpoint-push-platform/model.coffee
+++ b/app/pods/remote-endpoint-push-platform/model.coffee
@@ -28,6 +28,7 @@ RemoteEndpointPushPlatform = Model.extend
 # Declare available types and their human-readable names
 types = 'osx ios gcm fcm mqtt'.split(' ').map (type) ->
   name: t "types.push-platform.#{type}"
+  nameKey: "types.push-platform.#{type}"
   slug: type
   value: type
 

--- a/app/pods/remote-endpoints/index/controller.coffee
+++ b/app/pods/remote-endpoints/index/controller.coffee
@@ -22,15 +22,15 @@ RemoteEndpointsIndexController = Ember.Controller.extend
     label: 'fields.name'
     type: 'string'
   ,
-    name: 'platformName'
+    name: 'platform.nameKey'
     label: 'fields.type'
-    type: 'string'
+    type: 't'
   ,
     name: 'location'
     label: 'fields.location'
     type: 'string'
   ,
-    name: 'statusTypeName'
+    name: 'statusType.nameKey'
     label: 'fields.status'
     type: 'status-label'
   ,

--- a/app/pods/shared-component/model.coffee
+++ b/app/pods/shared-component/model.coffee
@@ -51,6 +51,7 @@ SharedComponent = Model.extend
 # Declare available types and their human-readable names
 types = 'single multi js'.split(' ').map (type) ->
   name: t "types.proxy-endpoint-component.#{type}"
+  nameKey: "types.proxy-endpoint-component.#{type}"
   slug: type
   value: type
 

--- a/app/templates/components/ap-model-field/-select-name-key.hbs
+++ b/app/templates/components/ap-model-field/-select-name-key.hbs
@@ -1,0 +1,17 @@
+{{#x-select
+  name=name
+  id=idName
+  value=value
+  required=required
+  disabled=disabled
+  class='form-control'}}
+
+  {{#if prompt}}
+    {{#x-option}}{{prompt}}{{/x-option}}
+  {{/if}}
+
+  {{#each options as |option|}}
+    {{#x-option value=option.value}}{{t option.nameKey}}{{/x-option}}
+  {{/each}}
+
+{{/x-select}}

--- a/app/templates/components/ap-table-auto-index-cell/status-label.hbs
+++ b/app/templates/components/ap-table-auto-index-cell/status-label.hbs
@@ -1,5 +1,5 @@
 {{#if (get model field.name)}}
   <span class="label label-{{if model.statusIsError 'danger'}}{{if model.statusIsSuccess 'success'}}{{if model.statusIsPending 'info'}}{{if model.statusIsProcessing 'warning'}}">
-    {{get model field.name}}{{#if model.status_message}}: {{model.status_message}}{{/if}}
+    {{t (get model field.name)}}{{#if model.status_message}}: {{model.status_message}}{{/if}}
   </span>
 {{/if}}

--- a/app/templates/components/ap-table-auto-index-cell/t.hbs
+++ b/app/templates/components/ap-table-auto-index-cell/t.hbs
@@ -1,0 +1,1 @@
+{{t (get model field.name)}}


### PR DESCRIPTION
Fixes a bug where some pre-rendered translation strings would be empty in some scenarios.  This is
fixed by relying less on pre-rendering and instead moving rendering into templates.  This resolves
most of the symptoms, but a complete fix means eliminating all pre-rendered translations entirely.
Fixes [#138430743]