### PR TITLE
chore(version): Add show_version config option that defaults to false

### DIFF
--- a/app/pods/application/controller.coffee
+++ b/app/pods/application/controller.coffee
@@ -3,6 +3,7 @@
 
 ApplicationController = Ember.Controller.extend Ember.Evented,
   version: config.version
+  show_version: config.show_version?.toString() is 'true'
   dev_mode: config.dev_mode?.toString() is 'true'
   session: Ember.inject.service()
 

--- a/app/pods/application/header/template.hbs
+++ b/app/pods/application/header/template.hbs
@@ -15,7 +15,7 @@
 
       {{#link-to 'application' class='navbar-brand'}}
         {{ap-brand}}
-        {{#if version}}
+        {{#if show_version}}
           <span class="ap-brand ap-brand-version hidden-xs hidden-sm">{{version}}</span>
         {{/if}}
       {{/link-to}}<!-- /.navbar-brand -->

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,6 +47,7 @@ module.exports = function(environment) {
     registration_enabled: true, // expose the user registration UI?
 
     version: null,
+    show_version: false,
     dev_mode: false,
     go_os: null,
     remote_endpoint_types_enabled: null,
@@ -87,6 +88,9 @@ module.exports = function(environment) {
     ENV.api.swaggerViewerPath = '/swagger';
     ENV.api.swaggerJsonPath = '/swagger';
 
+    ENV.version = '0.0.0';
+    ENV.show_version = true;
+
     ENV.go_os = 'darwin';
     ENV.APP.notifications = true;
     ENV.APP.mockNotifications = true;
@@ -118,6 +122,7 @@ module.exports = function(environment) {
     ENV.api.host = 'ADMIN_API_HOST';
     ENV.registration_enabled = 'REGISTRATION_ENABLED';
     ENV.version = 'VERSION';
+    ENV.show_version = 'SHOW_VERSION';
     ENV.dev_mode = 'DEV_MODE';
     ENV.go_os = 'GO_OS';
     ENV.remote_endpoint_types_enabled = 'REMOTE_ENDPOINT_TYPES_ENABLED';


### PR DESCRIPTION
Backend may interpolate the SHOW_VERSION string to "true" to show the version in the UI.  Any other
value, including empty, is interpreted as false and the version will not be shown.