### PR TITLE
fix(auth): Redirect to standard post-auth route before logout

### DIFF
--- a/app/pods/application/route.coffee
+++ b/app/pods/application/route.coffee
@@ -141,6 +141,9 @@ ApplicationRoute = Ember.Route.extend ApplicationRouteMixin,
 
   actions:
     invalidateSession: ->
+      # Transition away from the current route so that post login doesn't
+      # attempt to redirect to what may be inaccessible to a different user.
+      @transitionTo config['simple-auth'].routeAfterAuthentication
       @get('session').invalidate()
     localeChange: (locale) ->
       window.location.search = "lng=#{locale}"


### PR DESCRIPTION
Normally, the login form attemps to redirect the user to the last seen route.  When a user logs out
while on a page inaccessible to another user who subsequently logs in, this results in an error.
This fix redirects to the standard post-auth route, accessible to all users, before logging out.

Fixes [#139828299]