### PR TITLE
perf(tests): Add ember-exam for test parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
 node_js:
-  - 7
   - 6
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "commit": "git-cz",
     "build": "ember build",
     "start": "ember server",
-    "test": "ember test",
+    "test": "ember exam --split=4 --parallel",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "config": {
@@ -62,6 +62,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.10.0",
     "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-exam": "0.6.0",
     "ember-export-application-global": "^1.0.5",
     "ember-i18next": "2.0.0-beta.2",
     "ember-load-initializers": "^0.5.1",

--- a/testem.js
+++ b/testem.js
@@ -3,6 +3,7 @@ module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
+  "parallel": 4,
   "launch_in_ci": [
     "PhantomJS"
   ],


### PR DESCRIPTION
Split tests into 4 partitions and run in parallel for faster completion times.  Dump Node 7 from
test matrix.